### PR TITLE
add csv export for admins

### DIFF
--- a/app/controllers/record_attachments_controller.rb
+++ b/app/controllers/record_attachments_controller.rb
@@ -43,7 +43,6 @@ class RecordAttachmentsController < ApplicationController
   end
 
 
-
   private
     def record_attachment_params
       params.require(:record_attachment).permit(

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,5 +1,7 @@
 class RecordsController < ApplicationController
-  
+
+  respond_to :html, :json, :csv
+
   # before any method in the records controller is called,
   # ensure the user is authenticated
   before_filter CASClient::Frameworks::Rails::Filter
@@ -10,6 +12,10 @@ class RecordsController < ApplicationController
   before_action only: [:show] do
     requested_record = Record.find_by(id: params[:id])
     check_user_privileges(requested_record)
+  end
+
+  before_action only: [:csv] do
+    check_admin_privileges()
   end
 
   # only allow those who created records to edit, update, or destroy the records
@@ -26,6 +32,11 @@ class RecordsController < ApplicationController
   # GET /records.json
   def index
     @records = Record.all
+  end
+
+  def csv
+    @all_records = RecordAttachment.joins(:record)
+    respond_with(@all_records)
   end
 
   # GET /records/1

--- a/app/models/record_attachment.rb
+++ b/app/models/record_attachment.rb
@@ -282,4 +282,8 @@ class RecordAttachment < ActiveRecord::Base
     end
   end
 
+  def as_csv
+    attributes
+  end
+
 end

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,0 +1,25 @@
+###
+# @author: florish
+#   see SO 5182344
+###
+
+require 'csv' # adds a .to_csv method to Array instances
+
+class Array 
+  alias old_to_csv to_csv #keep reference to original to_csv method
+
+  def to_csv(options = Hash.new)
+    # override only if first element actually has as_csv method
+    return old_to_csv(options) unless self.first.respond_to? :as_csv
+    # use keys from first row as header columns
+    out = first.as_csv.keys.to_csv(options)
+    self.each { |r| out << r.as_csv.values.to_csv(options) }
+    out
+  end
+end
+
+ActionController::Renderers.add :csv do |csv, options|
+  csv = csv.respond_to?(:to_csv) ? csv.to_csv() : csv
+  self.content_type ||= Mime::CSV
+  self.response_body = csv
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,9 +45,11 @@ VoicesRails::Application.routes.draw do
   # when users click 'cancel all' on form page
   delete "destroy_unsaved_attachments" => "record_attachments#destroy_unsaved_attachments"
 
-  # provie route that will send a request for a record to be removed
+  # provide route that will send a request for a record to be removed
   get "report_record" => "report_record#create"
 
+  # data download endpoint
+  get "csv" => "records#csv", :defaults => { :format => 'csv' }
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
Admins can now download a csv export by visiting the `/csv` route.

Closes #24 